### PR TITLE
Added compatibility with Lumen and some code cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,15 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": ">=5.3"
+        "illuminate/contracts": ">=5.4",
+        "illuminate/database": ">=5.4",
+        "illuminate/queue": ">=5.4",
+        "illuminate/support": ">=5.4",
+        "nesbot/carbon": ">=1.21"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4",
-        "orchestra/testbench": "^3.5"
+        "phpunit/phpunit": ">=5.7",
+        "orchestra/testbench": ">=3.4"
     },
     "extra": {
         "laravel": {

--- a/src/JobStatus.php
+++ b/src/JobStatus.php
@@ -3,7 +3,6 @@
 namespace Imtigger\LaravelJobStatus;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Imtigger\LaravelJobStatus
@@ -25,23 +24,28 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property-read mixed $is_executing
  * @property-read mixed $is_failed
  * @property-read mixed $is_finished
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereAttempts($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereCreatedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereFinishedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereId($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereInput($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereJobId($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereOutput($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereProgressMax($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereProgressNow($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereQueue($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereStartedAt($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereStatus($value)
- * @method static \Illuminate\Database\Query\Builder|\App\Models\JobStatus whereType($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereAttempts($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereCreatedAt($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereFinishedAt($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereId($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereInput($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereJobId($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereOutput($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereProgressMax($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereProgressNow($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereQueue($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereStartedAt($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereStatus($value)
+ * @method static \Illuminate\Database\Query\Builder|\Imtigger\LaravelJobStatus\JobStatus whereType($value)
  * @mixin \Eloquent
  */
 class JobStatus extends Model
 {
+    const STATUS_QUEUED = 'queued';
+    const STATUS_EXECUTING = 'executing';
+    const STATUS_FINISHED = 'finished';
+    const STATUS_FAILED = 'failed';
+
     public $dates = ['started_at', 'finished_at', 'created_at', 'updated_at'];
     protected $guarded = [];
 
@@ -63,22 +67,27 @@ class JobStatus extends Model
     
     public function getIsEndedAttribute()
     {
-        return in_array($this->status, ['failed', 'finished']);
+        return in_array($this->status, [self::STATUS_FAILED, self::STATUS_FINISHED]);
     }
 
     public function getIsFinishedAttribute()
     {
-        return in_array($this->status, ['finished']);
+        return $this->status === self::STATUS_FINISHED;
     }
 
     public function getIsFailedAttribute()
     {
-        return in_array($this->status, ['failed']);
+        return $this->status === self::STATUS_FAILED;
     }
     
     public function getIsExecutingAttribute()
     {
-        return in_array($this->status, ['executing']);
+        return $this->status === self::STATUS_EXECUTING;
+    }
+
+    public function getIsQueuedAttribute()
+    {
+        return $this->status === self::STATUS_QUEUED;
     }
 
     /* Mutator */
@@ -90,5 +99,15 @@ class JobStatus extends Model
     public function setOutputAttribute($value)
     {
         $this->attributes['output'] = json_encode($value);
+    }
+
+    public static function getAllowedStatuses()
+    {
+        return [
+            self::STATUS_QUEUED,
+            self::STATUS_EXECUTING,
+            self::STATUS_FINISHED,
+            self::STATUS_FAILED
+        ];
     }
 }

--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -16,13 +16,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->publishes([
-            __DIR__ . '/migrations/2017_05_01_000000_create_job_statuses_table.php' => app_path('../database/migrations/2017_05_01_000000_create_job_statuses_table.php')
-        ], 'forms');
-
-        $this->publishes([
-            __DIR__ . '/config/job-status.php' => app_path('../config/job-status.php')
-        ], 'configs');        
+        $this->loadMigrationsFrom(__DIR__ . '/migrations');
 
         // Add Event listeners
         app(QueueManager::class)->before(function (JobProcessing $event) {

--- a/src/Trackable.php
+++ b/src/Trackable.php
@@ -39,8 +39,9 @@ trait Trackable
 
     protected function update(array $data)
     {
-        $entityClass = config('job-status.class', JobStatus::class);
-
+        /** @var JobStatus $entityClass */
+        $entityClass = app()->getAlias(JobStatus::class);
+        /** @var JobStatus $status */
         $status = $entityClass::find($this->statusId);
 
         if ($status != null) {
@@ -50,8 +51,9 @@ trait Trackable
 
     protected function prepareStatus()
     {
-        $entityClass = config('job-status.class', JobStatus::class);
-
+        /** @var JobStatus $entityClass */
+        $entityClass = app()->getAlias(JobStatus::class);
+        /** @var JobStatus $status */
         $status = $entityClass::create([
             'type' => static::class
         ]);

--- a/src/Trackable.php
+++ b/src/Trackable.php
@@ -47,6 +47,7 @@ trait Trackable
         if ($status != null) {
             return $status->update($data);
         }
+        return null;
     }
 
     protected function prepareStatus()

--- a/src/config/job-status.php
+++ b/src/config/job-status.php
@@ -1,4 +1,0 @@
-<?php
-return [
-    'class' => \Imtigger\LaravelJobStatus\JobStatus::class,
-];

--- a/src/migrations/2017_05_01_000000_create_job_statuses_table.php
+++ b/src/migrations/2017_05_01_000000_create_job_statuses_table.php
@@ -20,7 +20,7 @@ class CreateJobStatusesTable extends Migration
             $table->integer('attempts')->default(0);
             $table->integer('progress_now')->default(0);
             $table->integer('progress_max')->default(0);
-            $table->string('status', 16)->default('queued')->index();
+            $table->string('status', 16)->default(\Imtigger\LaravelJobStatus\JobStatus::STATUS_QUEUED)->index();
             $table->longText('input')->nullable();
             $table->longText('output')->nullable();
             $table->timestamps();


### PR DESCRIPTION
Hi,

these patches make this package usable also in Lumen by referencing only the core packages needed which are provided either by Lumen or Laravel framework.

I've also made some cleanup and made JobStatus' "status" strictly defined.
I've removed the config because it was only used for remaping JobStatus class. This can now be done using aliasing (provided by both Lumen and Laravel).

BR