### PR TITLE
Improvements (in consistency & flexibilty)

### DIFF
--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -50,7 +50,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
                 'status' => $entityClass::STATUS_FAILED,
                 'attempts' => $event->job->attempts(),
                 'finished_at' => Carbon::now(),
-                'output' => json_encode(['message' => $event->exception->getMessage()])
+                'output' => ['message' => $event->exception->getMessage()]
             ]);
         });
     }

--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -18,33 +18,36 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__ . '/migrations');
 
+	    /** @var JobStatus $entityClass */
+	    $entityClass = app()->getAlias(JobStatus::class);
+
         // Add Event listeners
-        app(QueueManager::class)->before(function (JobProcessing $event) {
+        app(QueueManager::class)->before(function (JobProcessing $event) use ($entityClass){
             $this->updateJobStatus($event->job, [
-                'status' => JobStatus::STATUS_EXECUTING,
+                'status' => $entityClass::STATUS_EXECUTING,
                 'job_id' => $event->job->getJobId(),
                 'attempts' => $event->job->attempts(),
                 'queue' => $event->job->getQueue(),
                 'started_at' => Carbon::now()
             ]);
         });
-        app(QueueManager::class)->after(function (JobProcessed $event) {
+        app(QueueManager::class)->after(function (JobProcessed $event) use($entityClass){
             $this->updateJobStatus($event->job, [
-                'status' => JobStatus::STATUS_FINISHED,
+                'status' => $entityClass::STATUS_FINISHED,
                 'attempts' => $event->job->attempts(),
                 'finished_at' => Carbon::now()
             ]);
         });
-        app(QueueManager::class)->failing(function (JobFailed $event) {
+        app(QueueManager::class)->failing(function (JobFailed $event) use ($entityClass){
             $this->updateJobStatus($event->job, [
-                'status' => JobStatus::STATUS_FAILED,
+                'status' => $entityClass::STATUS_FAILED,
                 'attempts' => $event->job->attempts(),
                 'finished_at' => Carbon::now()
             ]);
         });
-        app(QueueManager::class)->exceptionOccurred(function (JobExceptionOccurred $event) {
+        app(QueueManager::class)->exceptionOccurred(function (JobExceptionOccurred $event) use($entityClass) {
             $this->updateJobStatus($event->job, [
-                'status' => JobStatus::STATUS_FAILED,
+                'status' => $entityClass::STATUS_FAILED,
                 'attempts' => $event->job->attempts(),
                 'finished_at' => Carbon::now(),
                 'output' => json_encode(['message' => $event->exception->getMessage()])
@@ -64,7 +67,11 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
 
             $jobStatusId = $jobStatus->getJobStatusId();
 
-            $jobStatus = JobStatus::where('id', '=', $jobStatusId);
+	        /** @var JobStatus $entityClass */
+	        $entityClass = app()->getAlias(JobStatus::class);
+
+	        $jobStatus = $entityClass::where('id', '=', $jobStatusId);
+
             return $jobStatus->update($data);
         } catch (\Exception $e) {
             Log::error($e->getMessage());

--- a/src/Trackable.php
+++ b/src/Trackable.php
@@ -50,17 +50,17 @@ trait Trackable
         return null;
     }
 
-    protected function prepareStatus()
-    {
-        /** @var JobStatus $entityClass */
-        $entityClass = app()->getAlias(JobStatus::class);
-        /** @var JobStatus $status */
-        $status = $entityClass::create([
-            'type' => static::class
-        ]);
-        
-        $this->statusId = $status->id;
-    }
+	protected function prepareStatus(array $data = [])
+	{
+		/** @var JobStatus $entityClass */
+		$entityClass = app()->getAlias(JobStatus::class);
+
+		$data = array_merge(["type" => static::class], $data);
+		/** @var JobStatus $status */
+		$status = $entityClass::create($data);
+
+		$this->statusId = $status->id;
+	}
 
     public function getJobStatusId()
     {


### PR DESCRIPTION
Hi,

as it's possible to overwrite the alias `JobStatus` the `LaravelJobStatusServiceProvider`should also use the `$entityClass = app()->getAlias(JobStatus::class);` as it's then possible to override the status constants (even if the use case for that is really small I think for consistency it should be there)

The second change in `protected function prepareStatus(array $data = [])` allows to supply additional $data when creating new `job_statuses`-rows to avoid unnecessary database calls (in high concurrency application this might be an issue). I think it's not make the API more complex, it just adds flexibilty.

Kind regards