### PR TITLE
Array to string conversion exception when updating  `job_statuses`

### DIFF
--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -50,7 +50,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
                 'status' => $entityClass::STATUS_FAILED,
                 'attempts' => $event->job->attempts(),
                 'finished_at' => Carbon::now(),
-                'output' => ['message' => $event->exception->getMessage()]
+                'output' => json_encode(['message' => $event->exception->getMessage()])
             ]);
         });
     }


### PR DESCRIPTION
The output message should also be json encoded otherwise an Array to string conversion is thrown