### PR TITLE
publish package migration into project migrations

### DIFF
--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -18,6 +18,10 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__ . '/migrations');
 
+        $this->publishes([
+            __DIR__ . '/migrations/' => database_path('migrations')
+        ], 'migrations');
+
 	    /** @var JobStatus $entityClass */
 	    $entityClass = app()->getAlias(JobStatus::class);
 
@@ -60,7 +64,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
         try {
             $payload = $job->payload();
             $jobStatus = unserialize($payload['data']['command']);
-            
+
             if (!is_callable([$jobStatus, 'getJobStatusId'])) {
                 return null;
             }


### PR DESCRIPTION
When I was using this package I wanted to make changes to the migration based on certain constraints of our database, however, I was unable to do this as I was unable to publish the migration.

With this pull request if you add one extra (optional) step to the install process you are able to publish the migration using tags.

`php artisan vendor:publish --tag=migrations`

This then copies the migration into the `database\migrations` folder ready for execution.