### PR TITLE
Made JobStatus model configureable

### DIFF
--- a/config/job-status.php
+++ b/config/job-status.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'model' => \Imtigger\LaravelJobStatus\JobStatus::class,
+];

--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -18,12 +18,18 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__ . '/migrations');
 
+        $this->mergeConfigFrom(__DIR__ . '/../config/job-status.php', 'job-status');
+
         $this->publishes([
-            __DIR__ . '/migrations/' => database_path('migrations')
+            __DIR__ . '/migrations/' => database_path('migrations'),
         ], 'migrations');
 
+        $this->publishes([
+            __DIR__ . '/../config/' => config_path(),
+        ], 'config');
+
 	    /** @var JobStatus $entityClass */
-	    $entityClass = app()->getAlias(JobStatus::class);
+	    $entityClass = app(config('job-status.model'));
 
         // Add Event listeners
         app(QueueManager::class)->before(function (JobProcessing $event) use ($entityClass){
@@ -68,7 +74,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
             $jobStatusId = $jobStatus->getJobStatusId();
 
   	        /** @var JobStatus $entityClass */
-  	        $entityClass = app()->getAlias(JobStatus::class);
+  	        $entityClass = app(config('job-status.model'));
 
   	        $jobStatus = $entityClass::where('id', '=', $jobStatusId);
 

--- a/src/Trackable.php
+++ b/src/Trackable.php
@@ -42,7 +42,7 @@ trait Trackable
     protected function update(array $data)
     {
         /** @var JobStatus $entityClass */
-        $entityClass = app()->getAlias(JobStatus::class);
+        $entityClass = app(config('job-status.model'));
         /** @var JobStatus $status */
         $status = $entityClass::find($this->statusId);
 
@@ -55,13 +55,13 @@ trait Trackable
     protected function prepareStatus(array $data = [])
     {
         /** @var JobStatus $entityClass */
-        $entityClass = app()->getAlias(JobStatus::class);
+        $entityClass = app(config('job-status.model'));
 
         $data = array_merge(["type" => $this->getDisplayName()], $data);
         /** @var JobStatus $status */
         $status = $entityClass::create($data);
 
-        $this->statusId = $status->id;
+        $this->statusId = $status->getKey();
     }
 
     protected function getDisplayName()


### PR DESCRIPTION
We needed the same feature as described in #17.

I made the following changes:
* There is now a config file which lets you change the class that's being used.
* Said config is now published, and it's value is used when instantiating a new JobStatus
* Is now use `$this->statusId = $status->getKey();` instead of $status->id, so you can also change the primary key