### PR TITLE
Fixed model events not being triggered

### DIFF
--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -76,7 +76,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
             /** @var JobStatus $entityClass */
             $entityClass = app(config('job-status.model'));
 
-            $jobStatus = $entityClass::query()->where('id', '=', $jobStatusId);
+            $jobStatus = $entityClass::query()->where('id', '=', $jobStatusId)->firstOrFail();
 
             // Try to add attempts to the data we're saving - this will fail
             // for some drivers since they delete the job before we can check


### PR DESCRIPTION
Fixes #35 

Impact:
- We use a single extra DB call
- The update will now fail if the JobStatus isn't found in the database