### PR TITLE
Typo: fix path to migrations.

### DIFF
--- a/src/LaravelJobStatusServiceProvider.php
+++ b/src/LaravelJobStatusServiceProvider.php
@@ -19,7 +19,7 @@ class LaravelJobStatusServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/job-status.php', 'job-status');
 
         $this->publishes([
-            __DIR__ . '../database/migrations/' => database_path('migrations'),
+            __DIR__ . '/../database/migrations/' => database_path('migrations'),
         ], 'migrations');
 
         $this->publishes([


### PR DESCRIPTION
Related to issue #42 but I found that config file is published but not migration.
Just correct a typo on migration path.