### PR TITLE
Find job attempts from event job first.

### DIFF
--- a/src/JobStatusUpdater.php
+++ b/src/JobStatusUpdater.php
@@ -32,8 +32,12 @@ class JobStatusUpdater
         }
 
         try {
-            $data['attempts'] = $job->attempts();
+            $data['attempts'] = $event->job->attempts();
         } catch (\Exception $e) {
+            try {
+                $data['attempts'] = $job->attempts();
+            } catch (\Exception $e) {
+            }
         }
 
         $jobStatus->update($data);


### PR DESCRIPTION
With my settings, I found that all my jobs have only attempts = 1 even if they have been retry several times.

My settings: Laravel 5.8 and QUEUE_DRIVER=redis

When debugging I see that I can have the right attempts number from `$event->job->attempts()` instead of `$job->attempts()`.
So I propose the modification on this PR but I do not know if it is a good solution for all cases (not only my particular one).