### PR TITLE
Add table name to default model

### DIFF
--- a/src/JobStatus.php
+++ b/src/JobStatus.php
@@ -49,7 +49,10 @@ class JobStatus extends Model
     const STATUS_FAILED = 'failed';
     const STATUS_RETRYING = 'retrying';
 
+    protected $table = "job_statuses";
+
     public $dates = ['started_at', 'finished_at', 'created_at', 'updated_at'];
+
     protected $guarded = [];
 
     protected $casts = [


### PR DESCRIPTION
Add the table name to the default model is important because when someone wants to use a personalized model and extends the default one but using a different name, Laravel will try to solve the table name based on the name of the personalized model.

Adding the table name, avoid this automatic behaviour.

Eg.:

```php
<?php

namespace App\Models;

use Imtigger\LaravelJobStatus\JobStatus;

class Cron extends JobStatus
{

    protected $table = "job_statuses"; // When extending JobStatus, personalized models will always need this line if the filename is not "JobStatus". With this Pull Request, not anymore.

}
```