### PR TITLE
Fix/issue 53

### DIFF
--- a/src/EventManagers/DefaultEventManager.php
+++ b/src/EventManagers/DefaultEventManager.php
@@ -39,7 +39,7 @@ class DefaultEventManager extends EventManager
     public function exceptionOccurred(JobExceptionOccurred $event): void
     {
         $this->getUpdater()->update($event, [
-            'status' => ($event->job->attempts() === $event->job->maxTries()) ? $this->getEntity()::STATUS_FAILED : $this->getEntity()::STATUS_RETRYING,
+            'status' => ($event->job->attempts() >= $event->job->maxTries()) ? $this->getEntity()::STATUS_FAILED : $this->getEntity()::STATUS_RETRYING,
             'finished_at' => Carbon::now(),
             'output' => ['message' => $event->exception->getMessage()],
         ]);

--- a/src/JobStatus.php
+++ b/src/JobStatus.php
@@ -49,7 +49,10 @@ class JobStatus extends Model
     const STATUS_FAILED = 'failed';
     const STATUS_RETRYING = 'retrying';
 
+    protected $table = "job_statuses";
+
     public $dates = ['started_at', 'finished_at', 'created_at', 'updated_at'];
+
     protected $guarded = [];
 
     protected $casts = [

--- a/src/JobStatusUpdater.php
+++ b/src/JobStatusUpdater.php
@@ -43,7 +43,7 @@ class JobStatusUpdater
 
         if ($jobStatus->isFailed
             && isset($data['status'])
-            && $jobStatus::STATUS_FINISHED
+            && $data['status'] === $jobStatus::STATUS_FINISHED
         ) {
             unset($data['status']);
         }

--- a/src/JobStatusUpdater.php
+++ b/src/JobStatusUpdater.php
@@ -41,6 +41,13 @@ class JobStatusUpdater
             }
         }
 
+        if ($jobStatus->isFailed
+            && isset($data['status'])
+            && $jobStatus::STATUS_FINISHED
+        ) {
+            unset($data['status']);
+        }
+
         $jobStatus->update($data);
     }
 


### PR DESCRIPTION
The change in src/EventManagers/DefaultEventManager.php is to set the status to FAILED when maxTries is less than attempts, i.e. when maxTries is set to 0.

The change in src/JobStatusUpdater.php is to not set the status to FINISHED is the status is already FAILED