### PR TITLE
Add `updated_at` property to PHPDoc annotation

### DIFF
--- a/src/JobStatus.php
+++ b/src/JobStatus.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $input
  * @property string $output
  * @property string $created_at
+ * @property string $updated_at
  * @property string $started_at
  * @property string $finished_at
  * @property mixed  $is_ended


### PR DESCRIPTION
This PR adds the missing `updated_at` property to the PHPDoc annotation of the `JobStatus` model.