### PR TITLE
Fix conflicting logic when parsing job data (IMPORTANT)

### DIFF
--- a/src/JobStatusUpdater.php
+++ b/src/JobStatusUpdater.php
@@ -67,7 +67,13 @@ class JobStatusUpdater
         try {
             $payload = $event->job->payload();
 
-            return unserialize($payload['data']['command']);
+            if (is_array($payload['data'])) {
+                if (array_key_exists('command', $payload['data'])) {
+                    return unserialize($payload['data']['command']);
+                }
+            }
+
+            return null;
         } catch (\Throwable $e) {
             Log::error($e->getMessage());
 


### PR DESCRIPTION
## Description

This pull request changes the `parseJob` method to ensure that `$payload['data']` is an array and that the `command` property exists before unserializing the data. The reason for this change is to make sure that the data being deserialized exists when the job is received. Additionally, this change is necessary to resolve a conflict between this package and any other queue-related packages in the web including my package https://github.com/amranidev/micro-bus.

For example, there was an issue reported by a user of [micro-bus ](https://github.com/amranidev/micro-bus) that conflicts with this package. The reason for the conflict is that the other package receives data from the queue as a string, and it's not serialized. This is because the other package is used for event-driven microservice architecture and allows developers to use protocol buffers if they want. Protocol buffers require the data to be transmitted as strings.

The developer reported the issue here: https://github.com/amranidev/micro-bus/issues/24

## Changes

This pull request changes the parseJob method to include the following steps:

- Check if `$payload['data']` exists and is an array.
- Check if `$payload['data']['command']` exists.

If both checks pass, unserialize the data and return it.

## Testing

We have tested this change locally and verified that it works as expected.

## Related Issue

This pull request addresses the issue reported by a user of the micro-bus package: https://github.com/amranidev/micro-bus/issues/24